### PR TITLE
Rework pauses of offscreen applets

### DIFF
--- a/common/js/CindyApp.js
+++ b/common/js/CindyApp.js
@@ -115,14 +115,18 @@ class CindyApp extends Application {
 
     pause() {
         console.log(`pause ${this.constructor.name}`);
-        if (this._isReady)
+        if (this._isReady) {
             this.cindy.evokeCS('pause();');
+            this.cindy.stop();
+        }
     }
 
     resume() {
         console.log(`resume ${this.constructor.name}`);
-        if (this._isReady)
+        if (this._isReady) {
             this.cindy.evokeCS('resume();');
+            this.cindy.play();
+        }
     }
 
     restart(pauseAfterRestart) {

--- a/ifs/IFS_init.cs
+++ b/ifs/IFS_init.cs
@@ -196,9 +196,7 @@ resume():=(
 );
 
 reset() := (
-  paused = false;
   framecnt = 0;
   select(randomint(length(poss)-1)+1);
   idleanimation = true;
-  playanimation();
 );

--- a/surfer/Surfer_init.cs
+++ b/surfer/Surfer_init.cs
@@ -362,6 +362,4 @@ resume():=(
 reset() := (
   select(randomint(length(poss)-1)+1);
   idleanimation = true;
-  paused = false;
-  playanimation();
 );


### PR DESCRIPTION
With this PR, the resources should be better managed by ensuring that widgets that are not on screen are indeed paused.

The old CindyScript functions are still evaluated because often some logic is encoded in these functions.