### PR TITLE
Resolve issues around pause/resume/reset

### DIFF
--- a/car-park/CarParkApp.js
+++ b/car-park/CarParkApp.js
@@ -10,7 +10,7 @@ class CarParkApp extends CindyApp {
             appName: 'Ausparken',
             appDescription: 'Wer schafft es, das rote Rennauto auszuparken? Leider stehen einige Autos im Weg, denen wiederum andere Autos im Weg stehen. Dieses Knobelspiel wurde 1970 von Nobuyuki Yoshigahara erfunden.',
             pauseScript: '',
-            resumeScript: '',
+            resumeScript: 'pauseanimation();',
         };
     }
 

--- a/car-park/CarPark_init.cs
+++ b/car-park/CarPark_init.cs
@@ -453,4 +453,5 @@ reset():=(
     if(special!=[],
      drawobj(special,.9);
     );
+    pauseanimation();
 );

--- a/common/js/CindyApp.js
+++ b/common/js/CindyApp.js
@@ -4,6 +4,7 @@ class CindyApp extends Application {
     constructor(config = {}) {
         super(Object.assign(CindyApp.defaultConfig, config));
         console.log("CindyApp called");
+        this._isCindyPaused = false;
         this._cindy = null;
         this._cindyPromise = (async () => createCindy.newInstance(await this.cindyArgs))()
             .then(cindy => this._cindy = cindy);
@@ -112,8 +113,9 @@ class CindyApp extends Application {
     pause() {
         super.pause();
         if (this._isReady) {
+            this.cindy.pause();
             this.cindy.evokeCS(this.config.pauseScript);
-            this.cindy.stop();
+            this._isCindyPaused = true;
         }
     }
 
@@ -122,13 +124,17 @@ class CindyApp extends Application {
         if (this._isReady) {
             this.cindy.evokeCS(this.config.resumeScript);
             this.cindy.play();
+            this._isCindyPaused = false;
         }
     }
 
     reset() {
         super.reset();
         if (this._isReady) {
+            this.cindy.stop()
             this.cindy.evokeCS(this.config.resetScript);
+            if(!this._isCindyPaused)
+                this.cindy.play();
         }
     }
 }

--- a/common/js/CindyApp.js
+++ b/common/js/CindyApp.js
@@ -114,17 +114,17 @@ class CindyApp extends Application {
         super.pause();
         if (this._isReady) {
             this.cindy.pause();
-            this.cindy.evokeCS(this.config.pauseScript);
             this._isCindyPaused = true;
+            this.cindy.evokeCS(this.config.pauseScript);
         }
     }
 
     resume() {
         super.resume();
         if (this._isReady) {
-            this.cindy.evokeCS(this.config.resumeScript);
             this.cindy.play();
             this._isCindyPaused = false;
+            this.cindy.evokeCS(this.config.resumeScript);
         }
     }
 
@@ -132,9 +132,9 @@ class CindyApp extends Application {
         super.reset();
         if (this._isReady) {
             this.cindy.stop()
-            this.cindy.evokeCS(this.config.resetScript);
             if(!this._isCindyPaused)
                 this.cindy.play();
+            this.cindy.evokeCS(this.config.resetScript);
         }
     }
 }

--- a/double-pendulum/DoublePendulum_init.cs
+++ b/double-pendulum/DoublePendulum_init.cs
@@ -7,11 +7,28 @@ oldb=B.xy;
 oldc=C.xy;
 
 n=300;
+externalpaused = false;
+
+pause():=(
+  externalpaused = true;
+);
+
+resume():=(
+  externalpaused = false;
+  lastsimulationtime = 0;
+);
+
+triggerinternalanimation():=(
+  if(pressed1 & !externalpaused,
+    lastsimulationtime = 0;
+    resetclock();
+    playanimation();
+    ,
+    pauseanimation()
+  );
+);
 
 reset():=(
-  resetclock();
-  lastsimulationtime = 0;
-  stopanimation();
   A.homog=(4, -2.40740, 0.462962);
   B.homog=(8, 4, 1);
   C.homog=(9, 7, 1);
@@ -20,19 +37,6 @@ reset():=(
   l=[];
   pressed1=true;
   pressed2=true;
+  triggerinternalanimation();
 );
 reset();
-
-pause():=(
-  pauseanimation();
-);
-
-resume():=(
-  if(pressed1,
-    lastsimulationtime = 0;
-    resetclock();
-    playanimation();
-    ,
-    pauseanimation()
-  );
-);

--- a/double-pendulum/DoublePendulum_init.cs
+++ b/double-pendulum/DoublePendulum_init.cs
@@ -1,15 +1,12 @@
 button1=[[14+9,7],[20+9,7],[20+9,8.7],[14+9,8.7]];
 button2=[[14+9,4],[20+9,4],[20+9,5.7],[14+9,5.7]];
 
-pressed1=true;
-pressed2=true;
+
 
 oldb=B.xy;
 oldc=C.xy;
 
-l = [];
 n=300;
-lastsimulationtime = 0;
 
 reset():=(
   resetclock();
@@ -21,21 +18,21 @@ reset():=(
   F.homog=(3.4, -4, -0.5);
   G.homog=(4, -2.1882352, -0.588235);
   l=[];
-  //pressed1=true;
-  //pressed2=false;
+  pressed1=true;
+  pressed2=true;
 );
+reset();
 
 pause():=(
-  l = [];
-  //pressed1=false;
   pauseanimation();
 );
 
 resume():=(
-  playanimation();
-  //pressed1 = true;
-  //pressed2 = true;
-  lastsimulationtime = 0;
-  resetclock();
-  playanimation();
+  if(pressed1,
+    lastsimulationtime = 0;
+    resetclock();
+    playanimation();
+    ,
+    pauseanimation()
+  );
 );

--- a/double-pendulum/DoublePendulum_init.cs
+++ b/double-pendulum/DoublePendulum_init.cs
@@ -16,6 +16,7 @@ pause():=(
 resume():=(
   externalpaused = false;
   lastsimulationtime = 0;
+  triggerinternalanimation();
 );
 
 triggerinternalanimation():=(

--- a/double-pendulum/DoublePendulum_mousedown.cs
+++ b/double-pendulum/DoublePendulum_mousedown.cs
@@ -1,10 +1,10 @@
 mpo=mouse().xy;
 if(mpo.x>button1_1_1 & mpo.x<button1_2_1 & mpo.y>button1_1_2 & mpo.y<button1_3_2,
-  if(pressed1,
-    stopanimation(),
-    lastsimulationtime = 0; l=[]; playanimation();
-  );
   pressed1=!pressed1;
+  if(pressed1,
+    resume(),
+    pause()
+  );
 );
 if(mpo.x>button2_1_1 & mpo.x<button2_2_1 & mpo.y>button2_1_2 & mpo.y<button2_3_2,pressed2=!pressed2);
 

--- a/double-pendulum/DoublePendulum_mousedown.cs
+++ b/double-pendulum/DoublePendulum_mousedown.cs
@@ -1,10 +1,7 @@
 mpo=mouse().xy;
 if(mpo.x>button1_1_1 & mpo.x<button1_2_1 & mpo.y>button1_1_2 & mpo.y<button1_3_2,
   pressed1=!pressed1;
-  if(pressed1,
-    resume(),
-    pause()
-  );
+  triggerinternalanimation();
 );
 if(mpo.x>button2_1_1 & mpo.x<button2_2_1 & mpo.y>button2_1_2 & mpo.y<button2_3_2,pressed2=!pressed2);
 

--- a/event-tester/EventTesterApp.js
+++ b/event-tester/EventTesterApp.js
@@ -8,6 +8,9 @@ class EventTesterApp extends CindyApp {
     static get defaultConfig() {
         return {
             appName: 'EVENT TESTER',
+            pauseScript: '',
+            resumeScript: '',
+            resetScript: '',
         };
     }
 

--- a/ifs/IFS_draw.cs
+++ b/ifs/IFS_draw.cs
@@ -1,10 +1,10 @@
-exalpha = sqrt(clamp(1-(seconds()-waittime)/explaintime)*clamp(seconds()/waittime));
+exalpha = sqrt(clamp(1-(myseconds()-waittime)/explaintime)*clamp(myseconds()/waittime));
 
 if(idleanimation,
   forall(allpoints(),p,
     omega = sin((p:"xy0")_1*1000)/2;//some "random-deterministic" value for each point;
-    radius = .05*smoothclamp((seconds()-waittime-explaintime)/5);
-    p.xy = p:"xy0" + radius*(cos(omega*seconds()),sin(omega*seconds()));
+    radius = .05*smoothclamp((myseconds()-waittime-explaintime)/5);
+    p.xy = p:"xy0" + radius*(cos(omega*myseconds()),sin(omega*myseconds()));
   );
   framecnt = 0;
 );
@@ -14,7 +14,7 @@ static = framecnt>200 & exalpha<.001;
 
 if(static,
   pauseanimation();
-  errc("paused IFS because it is likely to be satic.");
+  errc("paused IFS because it is likely to be staic.");
 );
 framecnt = framecnt+1;
 
@@ -59,8 +59,8 @@ drawimage(L,R,"ifs");
 
 
 if(exalpha>0.01,
-  //t = mod(seconds(),2)/2;
-  t = -cos(max(0,seconds()-waittime))/2+.5;
+  //t = mod(myseconds(),2)/2;
+  t = -cos(max(0,myseconds()-waittime))/2+.5;
   iTrafos = t*apply(Trafos, T, T/T_3_3)+(1-t)*apply(Trafos,[[1,0,0],[0,1,0],[0,0,1]]); //mix with identity
   colorplot(L,R,"anim",
     color = [0,0,0];

--- a/ifs/IFS_init.cs
+++ b/ifs/IFS_init.cs
@@ -165,8 +165,10 @@ select(k) := (
 );
 
 init() := (
+  idleanimation = true;
   clearimage("ifs");
   clearimage("seed");
+  deltat = 0;
   resetclock();
   if(!paused,
     playanimation();
@@ -178,7 +180,6 @@ createimage("ifs", res, res);
 createimage("seed", res, res);
 createimage("anim", res, res);
 createimage("CF", 1, 1);
-select(1);
 
 applytrafo(T, p) := (
   h = T*[p_1,p_2,1];
@@ -187,23 +188,26 @@ applytrafo(T, p) := (
 
 pause():=(
   paused = true;
-  pauseanimation();
+  deltat = myseconds();
+  resetclock();
 );
 
 resume():=(
   paused = false;
-  select(sel);
-  playanimation();
-  framecnt = 0;
-  idleanimation = true;
+  resetclock();
 );
 
 reset() := (
   framecnt = 0;
   select(randomint(length(poss)-1)+1);
-  idleanimation = true;
 );
+reset();
 
 clamp(v) := min(max(0,v),1);
 
 smoothclamp(v) := .5-.5*cos(clamp(v)*pi);
+
+//time that has passed when app has been active
+myseconds() := (
+  seconds()+deltat;
+);

--- a/image-spiral/ImageSpiralApp.js
+++ b/image-spiral/ImageSpiralApp.js
@@ -9,6 +9,7 @@ class ImageSpiralApp extends CindyApp {
         return {
             appName: 'Spirale',
             appDescription: 'Ein Bild wird um ein Zentrum gedreht und gestaucht oder gestreckt, das nennt man eine <em>Drehstreckung</em>. Das so veränderte Bild wird wieder gedreht und um denselben Faktor gestaucht oder gestreckt und so weiter. Dadurch entstehen wie von selbst faszinierende Bilder.',
+            pauseScript: '',
         };
     }
 

--- a/image-spiral/ImageSpiral_init.cs
+++ b/image-spiral/ImageSpiral_init.cs
@@ -1,6 +1,4 @@
-sel=1;
-ss=1;
-pendanimation=true;
+ss = 1;
 images=[
 [(21,1),"test1",.9/ss],
 [(26,1),"test2",.7/ss],
@@ -9,26 +7,19 @@ images=[
 [(21,-10),"test5",.7/ss],
 [(26,-10),"test6",.5/ss]];
 
-pause():=(
-   stopanimation();
-      sel=ceil(random()*6);
-   if(sel>6,sel=6);
-   if(sel<1,sel=1);
-);
-
 resume():=(
-   if(pendanimation,playanimation());
-
+  if(pendanimation,
+    playanimation(),
+    pauseanimation()
+   );
 );
 
 reset():=(
-B.homog=(4, -0.3346613, 0.39840637);
-C.homog=(4, 1.22893871, 0.43593195);
-D.homog=(4, 1.9, 0.179533);
-E.homog=(5, 3.1, 0.2085930);
-G.homog=(4, 1.8, 0.1488095);
-//sel=1;
-pendanimation=true;
-
-    );
+  sel=ceil(random()*6);
+  if(sel>6,sel=6);
+  if(sel<1,sel=1);
+  pendanimation=true;
+  pinall = false;
+);
+reset();
 playanimation();

--- a/image-spiral/ImageSpiral_tick.cs
+++ b/image-spiral/ImageSpiral_tick.cs
@@ -1,4 +1,6 @@
-ttt=0.5;
-E.xy=gauss(complex(E-D)*exp(.03*i*ttt))+D;
-B.xy=gauss(complex(B)*exp(.003*i*ttt));
-C.xy=gauss(complex(C)*exp(.001*i*ttt));
+if(pendanimation,
+  ttt=0.5;
+  E.xy=gauss(complex(E-D)*exp(.03*i*ttt))+D;
+  B.xy=gauss(complex(B)*exp(.003*i*ttt));
+  C.xy=gauss(complex(C)*exp(.001*i*ttt));
+);

--- a/iornament/iOrnamentApp.js
+++ b/iornament/iOrnamentApp.js
@@ -8,8 +8,7 @@ class iOrnamentApp extends CindyApp {
   static get defaultConfig() {
     return {
       appName: 'iOrnament',
-      pauseScript: '',
-      resumeScript: '',
+      pauseScript: ''
     };
   }
 

--- a/iornament/iOrnament_init.cs
+++ b/iornament/iOrnament_init.cs
@@ -1113,9 +1113,13 @@ apply(strokelist,strox,
  );
 );
 );
+resetdraw();
 );
 reset();
 
+resume():= (
+  pauseanimation();
+);
 
 resetdraw():=(
 clearimage("tile");
@@ -1137,3 +1141,4 @@ playanimation();
 fundsel=false;
 glowing=false;
 symannot=false;
+pauseanimation();

--- a/iornament/iOrnament_tick.cs
+++ b/iornament/iOrnament_tick.cs
@@ -1,5 +1,5 @@
 
-      if(strokecount>length(strokelist),pauseanimation(),
+  if(strokecount>length(strokelist),pauseanimation(),
         canvas(A,B,C,"tile",
             strox=strokelist_strokecount;
      size=strox_1_1;

--- a/kaleidoscope/KaleidoscopeApp.js
+++ b/kaleidoscope/KaleidoscopeApp.js
@@ -10,7 +10,6 @@ class KaleidoscopeApp extends CindyApp {
             appName: 'Kaleidoskop',
             appDescription: 'Bei diesem Kaleidoskop mit 3 Spiegeln ergeben sich Muster, die sich ins Unendliche fortsetzen. Am großen Schiebeschalter kann man einstellen, wie oft gespiegelt werden soll. An den Punkten läßt sich die Position von Bild und Kaleidoskop verändern.',
             pauseScript: '',
-            resumeScript: '',
         };
     }
 

--- a/kaleidoscope/Kaleidoscope_init.cs
+++ b/kaleidoscope/Kaleidoscope_init.cs
@@ -1,7 +1,3 @@
-type=1;
-
-
-sel=1;
 images=[
 [(28,-4),"bild",.4],
 [(28,-8),"bild2",.7],
@@ -9,29 +5,23 @@ images=[
 [(28,-16),"bild4",.5]
 ];
 
-pause():=(
-   stopanimation();
-);
-
-
 resume():=(
-   if(pendanimation,playanimation());
+   if(pendanimation,playanimation(),stopanimation());
 );
 
 reset():=(
+  A.homog=(4, 0.63313657, -1.04065347);
+  B.homog=(0.9043478, -4, 0.6749865);
+  D.homog=(-3.2947, -4, 0.289674);
+  E.homog=(4, -1.4651206, 0.23502179);
+  G.homog=(4, -1.81823465, -0.2468792697);
+  M.homog=(4, 0, 0.13995);
+  L.homog=(4, -2.09576888, 0.181818);
+  pendanimation=true;
 
-A.homog=(4, 0.63313657, -1.04065347);
-B.homog=(0.9043478, -4, 0.6749865);
-D.homog=(-3.2947, -4, 0.289674);
-E.homog=(4, -1.4651206, 0.23502179);
-G.homog=(4, -1.81823465, -0.2468792697);
-M.homog=(4, 0, 0.13995);
-L.homog=(4, -2.09576888, 0.181818);
-pendanimation=true;
-
-type=1;
-sel=1;
-	);
-pendanimation=true;
+  type=1;
+  sel=randomint(4)+1;
+);
+reset();
 
 playanimation();

--- a/lunar-lockout/LunarApp.js
+++ b/lunar-lockout/LunarApp.js
@@ -10,6 +10,8 @@ class LunarApp extends CindyApp {
       appName: 'Lunar Lockout',
       appDescription: 'Wer schafft es den violetten Kreis in die Mitte zu bewegen? Dazu können die verschiedenen Kreise jeweils so weit wie möglich nach oben, rechts, unten oder links verschoben werden.',
       appCredits: 'Level & Implemtierung: Aaron Montag. Spielidee inspiriert von Hiroshi Yamamoto.',
+      pauseScript: '',
+      resumeScript: '',
     };
   }
 

--- a/lunar-lockout/Lunar_draw.cs
+++ b/lunar-lockout/Lunar_draw.cs
@@ -48,3 +48,8 @@ setk(mod(k, length(levels))+1)
 );
 
 );
+
+//save ressources
+if(mode!="animation" & !solved,
+  pauseanimation();
+);

--- a/lunar-lockout/Lunar_init.cs
+++ b/lunar-lockout/Lunar_init.cs
@@ -25,7 +25,7 @@ reset(k) := (
 
     mode = "select";
     T = 0;
-    resetclock();
+    resetclock();playanimation();
 );
 
 computeP(k) := (
@@ -49,15 +49,6 @@ isfree(f) := (
 );
 lastk = 0;
 setk(1);
-
-
-pause():=(
-  pauseanimation();
-);
-
-resume():=(
-  playanimation();
-);
 
 reset() := (
   setk(randomint(length(levels)-1)+1);

--- a/lunar-lockout/Lunar_mouseup.cs
+++ b/lunar-lockout/Lunar_mouseup.cs
@@ -29,7 +29,7 @@ if(targetsonray==[],
    posB = pos;
    T = |posB_sel - posA_sel|/10;
    mode = "animation";
-   resetclock();
+   resetclock();playanimation();
    resetpossible = true;
    sel = 0;
   );

--- a/platonic-solids/PlatonicSolidsApp.js
+++ b/platonic-solids/PlatonicSolidsApp.js
@@ -10,7 +10,9 @@ class PlatonicSolidsApp extends CindyApp {
             appName: 'Platonische Körper',
             appDescription: 'Hier können platonische Körper ineinander geschachtelt werden. Man achte auf die Vielfalt an Querbeziehungen, die sich durch die Art des Schachtelns ergeben.',
             resetScript: 'resetAll();',
-            resumeScript: ''
+            resumeScript: '',
+            pauseScript: '',
+
         };
     }
 

--- a/platonic-solids/PlatonicSolids_init.cs
+++ b/platonic-solids/PlatonicSolids_init.cs
@@ -426,7 +426,6 @@ reset():=(
  objects=[];
  count=1;
  celllist=[];
- wx = cos(seconds())/200; wy = sin(seconds())/200;
 );
 
 
@@ -615,9 +614,7 @@ resetall():=(
    sequenz=[2];
    edges=true;
    S.homog=(4, 0.3131313, -0.2525252);
-);
-pause():=(
-   pauseanimation();
+   wx = cos(seconds())/200; wy = sin(seconds())/200;
 );
 
 
@@ -640,10 +637,4 @@ dehighlight(but):= fillpoly(
       off+but+(1,1)*w
   ),color->(1,1,1.5)*.2,alpha->0.7
 
-);
-
-
-resume() := (
-  playanimation();
-  wx = cos(seconds())/200; wy = sin(seconds())/200;
 );

--- a/platonic-solids/PlatonicSolids_mousedown.cs
+++ b/platonic-solids/PlatonicSolids_mousedown.cs
@@ -2,7 +2,8 @@ dragging=false;
 if(|mouse().x|<13,
  startx=mouse().x;
  starty=mouse().y;
- dragging=|mouse().xy,S|>.3
+ //dragging=|mouse().xy,S|>.3
+ dragging = true;
 //&|mouse().xy,X|>.3
 //&|mouse().xy,C|>.3
 ;

--- a/platonic-solids/PlatonicSolids_mousedrag.cs
+++ b/platonic-solids/PlatonicSolids_mousedrag.cs
@@ -1,36 +1,18 @@
 if(|mouse().x|<13,
 
 if(dragging,
-
+errc("drag");
 xx=mouse().x;
 yy=mouse().y;
-wy=(startx-xx)*.2;
-wx=-(starty-yy)*.2;
 
-mmmx=[
-  [1,0,0],
-  [0,cos(wx),sin(wx)],
-  [0,-sin(wx),cos(wx)]
-];
-
-
-mmmy=[
-  [cos(wy),0,-sin(wy)],
-  [0,1,0],
-  [sin(wy),0,cos(wy)]
-];
-
-
-
-  mat=mmmx*mmmy*mat;
-
-
+fact = .98;
+wy=fact*wy+(1-fact)*(startx-xx)*.4;
+wx=fact*wx-(1-fact)*(starty-yy)*.4;
 
 startx=xx;
 starty=yy;
 
+if(|(wx,wy)|>0.0001,playanimation(), pauseanimation());
+
 );
-
-if(|(wx,wy)|>0.2,playanimation());
-
 );

--- a/platonic-solids/PlatonicSolids_tick.cs
+++ b/platonic-solids/PlatonicSolids_tick.cs
@@ -1,7 +1,7 @@
- wx=wx*0.998;
- wy=wy*0.998;
+ wx=wx*0.995;
+ wy=wy*0.995;
 
-if(|(wx,wy)|<0.001,pauseanimation();stopanimation(););
+if(|(wx,wy)|<0.0001,pauseanimation(),playanimation());
 
 sp=0.6;
 mmmx=[

--- a/polytope-morpher/PolytopeMorpherApp.js
+++ b/polytope-morpher/PolytopeMorpherApp.js
@@ -10,6 +10,7 @@ class PolytopeMorpherApp extends CindyApp {
             appName: 'Polyeder basteln',
             appDescription: 'Ausgehend von einem platonischen Körper kann man durch das Anwenden von drei Operationen neue symmetrische Körper erzeugen. Ein Druck auf den Zauberstab übernimmt das aktuelle Objekt als neuen Ausgangspunkt für die Verformungen.',
             resetScript: 'resetAll();',
+            pauseScript: '',
         };
     }
 

--- a/polytope-morpher/PolytopeMorpher_draw.cs
+++ b/polytope-morpher/PolytopeMorpher_draw.cs
@@ -13,8 +13,8 @@ if(W.y>=V.y,W.xy=V.xy);
 
 //layer(0);
 clrscr();
-errf(c):=errc(c);
-//errf(c):=();
+//errf(c):=errc(c);
+errf(c):=();
 //err("A1 "+seconds());
 //err(choice);
 //err(tchoice);

--- a/polytope-morpher/PolytopeMorpher_init.cs
+++ b/polytope-morpher/PolytopeMorpher_init.cs
@@ -433,12 +433,9 @@ resetall():=(
 
 
 );
-pause():=(
-   stopanimation();
-);
 
 resume():=(
-   if(pendinganimation,playanimation());
+   if(pendinganimation,playanimation(),pauseanimation());
 );
 
 highlight(but):= connect(

--- a/sphere-chaos/SphereChaosApp.js
+++ b/sphere-chaos/SphereChaosApp.js
@@ -9,6 +9,7 @@ class SphereChaosApp extends CindyApp {
         return {
             appName: 'Lichtstrahl',
             appDescription: 'Wenn sich ein Lichtstrahl zwischen kreisförmigen Spiegeln reflektiert, entsteht <em>deterministisches Chaos</em>: eine kleine Änderung kann unvorhersehbare Auswirkungen haben.  Was passiert, wenn der Lichtstrahl im Inneren eines Kreises startet?',
+            pauseScript: '',
         };
     }
 

--- a/sphere-chaos/SphereChaos_init.cs
+++ b/sphere-chaos/SphereChaos_init.cs
@@ -14,15 +14,12 @@ D.homog=(3,3,1);
 E.homog=(13, -3, 1);
 pendanimation=true;
 
-    );
+);
+reset();
 
-    playanimation();
 resume():=(
-   if(pendanimation,playanimation());
-
+   if(pendanimation,playanimation(), pauseanimation());
 );
-pause():=(
-   stopanimation();
 
-);
 pendanimation=true;
+playanimation();

--- a/surfer/SurferApp.js
+++ b/surfer/SurferApp.js
@@ -11,6 +11,8 @@ class SurferApp extends CindyApp {
       appName: 'Algebraische Flächen',
       appDescription: `Algebraische Flächen bestehen aus den Punkten im Raum, die bestimmte polynomielle Gleichungen in den Koordinaten erfüllen. So beschreibt z.B. die Formel\\n<em>x²+y²+z²-1=0</em>\\neine Kugel. Algebraische Kurven und Flächen sind sowohl in der angewandten, als auch in der reinen Mathematik von fundamentaler Bedeutung.`,
       appCredits: 'Aaron Montag',
+      pauseScript: '',
+      resumeScript: ''
     };
   }
 

--- a/surfer/Surfer_init.cs
+++ b/surfer/Surfer_init.cs
@@ -350,18 +350,6 @@ clipedScene(pixel) := (
   color //return value
 );
 
-paused = false;
-pause():=(
-  pauseanimation();
-  paused = true;
-);
-
-resume():=(
-  paused = false;
-  playanimation();
-  idleanimation = true;
-);
-
 reset() := (
   select(randomint(length(poss)-4)+4);//do not select the boring surfaces
   idleanimation = true;

--- a/surfer/Surfer_mousedown.cs
+++ b/surfer/Surfer_mousedown.cs
@@ -1,5 +1,3 @@
-if(!paused, playanimation());
-
 sx = mouse().x;
 sy = mouse().y;
 dragging = sx < .5 & sx > -.5 ;

--- a/swarm/SwarmApp.js
+++ b/swarm/SwarmApp.js
@@ -11,6 +11,7 @@ class SwarmApp extends CindyApp {
             appDescription: 'Das Schwarmverhalten entsteht dadurch, dass jeder Fisch einfachen Regeln folgt: anderen Fischen und Hindernissen ausweichen, zu den Nachbarfischen und mit ihnen schwimmen, oder einfach weiter schwimmen. Über die Schieberegel kann man die Parameter dieser Regeln anpassen.',
             pauseScript: '',
             resumeScript: '',
+            resetScript: '',
         };
     }
 

--- a/swarm/SwarmApp.js
+++ b/swarm/SwarmApp.js
@@ -9,6 +9,8 @@ class SwarmApp extends CindyApp {
         return {
             appName: 'Schwarmsimulator',
             appDescription: 'Das Schwarmverhalten entsteht dadurch, dass jeder Fisch einfachen Regeln folgt: anderen Fischen und Hindernissen ausweichen, zu den Nachbarfischen und mit ihnen schwimmen, oder einfach weiter schwimmen. Über die Schieberegel kann man die Parameter dieser Regeln anpassen.',
+            pauseScript: '',
+            resumeScript: '',
         };
     }
 

--- a/swarm/Swarm_init.cs
+++ b/swarm/Swarm_init.cs
@@ -1,4 +1,3 @@
-//  playanimation();
 feed=false;
 
 pts=allmasses()--[K,L,J];
@@ -7,10 +6,3 @@ apply(pts,#:"vold"=#.v);
 
 sizes=1.2*apply(pts,random()*.9+.8);
 colors=apply(pts,random());
-
-pause():=(
-  pauseanimation();
-);
-resume():=(
-  playanimation();
-);

--- a/tree/Tree_draw.cs
+++ b/tree/Tree_draw.cs
@@ -14,3 +14,5 @@ nn=12;
 // drawimage((-15,-11),(15,-11),"back");
 
 tree(A.homog,B.homog,nn);
+
+pauseanimation(); //draw the tree only once


### PR DESCRIPTION
In `CindyApp`, the `pause()` method so far called `stop()` on the Cindy instance. But this also results in reset the configuration of the geometric elements.

Properly mapping `CindyApp.[pause|resume|reset]()` to `cindy.[pause|play|stop] methods seems to resolve the recent inconsitencies around the pause/resume/reset behavior. Especially in the `swarm` app.

It also looks like most of the `pause()` and `resume()` handlers inside CindyScripts are unnecessary and may also have unintended side-effects. In my opinion, it makes sense to review all apps and check for proper behavior.

Also, the `reset()` functions should be reviewed. I have seen instances, where `reset()`

 - just replicates what `stop()` would do anyways (reset the geometric elements)
 - resets only part of the variables that are defined in the `init` scripts (this smells like side effects)

This pull request should only be (squash-)merged, when all apps are checked, fixed and tested:

 - [x] car-park
 - [x] double-pendulum
 - [x] event-tester
 - [x] ifs
 - [x] image-spiral
 - [x] iornament
 - [x] kaleidoscope
 - [x] lunar-lockout
 - [x] platonic-solids
 - [x] polytope-morpher
 - [x] solitaire
 - [x] sphere-chaos
 - [x] surfer
 - [x] swarm
 - [x] tree
