### PR TITLE
Grab only fish that are close to mouse

### DIFF
--- a/swarm/SwarmApp.js
+++ b/swarm/SwarmApp.js
@@ -59,7 +59,7 @@ class SwarmApp extends CindyApp {
         for (var i = 0; i < nn; i++) {
             gslp.push(
                 {
-                    name: "A" + i, type: "Free",
+                    name: "A" + i, type: "Free", narrow: true,
                     pos: [(Math.random() - .5) * 14, (Math.random() - .5) * 14],
                     color: [1, .5, .5], size: .1
                 }


### PR DESCRIPTION
Fish can be fed by pressing the mouse. However, in this case
also some fish that might have some big distance to the mouse
has been grabbed. This caused an awkward-looking bug because
all fish would swim to the mouse but only the selected one.