### PR TITLE
Do not allow to move elements outside of boundaries + reset button for physics

### DIFF
--- a/double-pendulum/DoublePendulum_draw.cs
+++ b/double-pendulum/DoublePendulum_draw.cs
@@ -26,8 +26,17 @@ restrict(G,minpt,maxpt);
 drawpoly(button1,color->gray(.8),size->4);
 fillpoly(button2,color->gray(if(pressed2,.3,.5)));
 drawpoly(button2,color->gray(.8),size->4);
+
+
+fillpoly(button3,color->gray(if(true,.3,.5)));
+drawpoly(button3,color->gray(.8),size->4);
+drawtext(button3_1+(2,.5),"Reset",color->(1,1,1),size->34);
+
+
+
 drawtext(button1_1+(2,.5),if(pressed1,"Stop","Start"),color->(1,1,1),size->34);
 drawtext(button2_1+(2,.5),"Spur",color->(1,1,1),size->34);
+
 draw(F,G, arrow->true,size->7,color->(1,1,1));
 
 if(pressed2,

--- a/double-pendulum/DoublePendulum_init.cs
+++ b/double-pendulum/DoublePendulum_init.cs
@@ -1,5 +1,6 @@
 button1=[[14+9,7],[20+9,7],[20+9,8.7],[14+9,8.7]];
 button2=[[14+9,4],[20+9,4],[20+9,5.7],[14+9,5.7]];
+button3=[[14+9,1],[20+9,1],[20+9,2.7],[14+9,2.7]];
 
 
 
@@ -29,13 +30,19 @@ triggerinternalanimation():=(
   );
 );
 
-reset():=(
+resetparams():=(
   A.homog=(4, -2.40740, 0.462962);
   B.homog=(8, 4, 1);
   C.homog=(9, 7, 1);
   F.homog=(3.4, -4, -0.5);
   G.homog=(4, -2.1882352, -0.588235);
+  B.v = [0,0];
+  C.v = [0,0];
   l=[];
+);
+
+reset():=(
+  resetparams();
   pressed1=true;
   pressed2=true;
   triggerinternalanimation();

--- a/double-pendulum/DoublePendulum_mousedown.cs
+++ b/double-pendulum/DoublePendulum_mousedown.cs
@@ -5,4 +5,5 @@ if(mpo.x>button1_1_1 & mpo.x<button1_2_1 & mpo.y>button1_1_2 & mpo.y<button1_3_2
 );
 if(mpo.x>button2_1_1 & mpo.x<button2_2_1 & mpo.y>button2_1_2 & mpo.y<button2_3_2,pressed2=!pressed2);
 
-;
+if(mpo.x>button3_1_1 & mpo.x<button3_2_1 & mpo.y>button3_1_2 & mpo.y<button3_3_2,
+resetparams());

--- a/ifs/IFS_draw.cs
+++ b/ifs/IFS_draw.cs
@@ -1,3 +1,17 @@
+restrict(p,mi,ma):=(
+  xx=max(min(p.x,ma.x),mi.x);
+  yy=max(min(p.y,ma.y),mi.y);
+  p.xy=(xx,yy);
+);
+minpt=(-.8,-.8);
+maxpt=(.8,.8);
+forall(used, P,
+  restrict(P,minpt,maxpt);
+);
+
+
+
+
 exalpha = sqrt(clamp(1-(myseconds()-waittime)/explaintime)*clamp(myseconds()/waittime));
 
 if(idleanimation,

--- a/swarm/Swarm_draw.cs
+++ b/swarm/Swarm_draw.cs
@@ -1,3 +1,15 @@
+restrict(p,mi,ma):=(
+  xx=max(min(p.x,ma.x),mi.x);
+  yy=max(min(p.y,ma.y),mi.y);
+  p.xy=(xx,yy);
+);
+minpt=(-9.5,-9.5);
+maxpt=(9.5,9.5);
+forall([J,L,K], P,
+  restrict(P,minpt,maxpt);
+);
+
+
 x=S.x;
 if(x<S1.x,x=S1.x);
 if(x>S2.x,x=S2.x);


### PR DESCRIPTION
With this PR, it now should be impossible to move elements (excluded fish) outside of the canvas.
Furthermore, double-pendulum can be reset.